### PR TITLE
Add support for index seeking

### DIFF
--- a/splicer/ast.py
+++ b/splicer/ast.py
@@ -294,4 +294,11 @@ class SliceOp(RelationalOp):
 
     return self.__class__(relation, *args)
 
-    
+
+# Physical Operations
+class IndexSeek(RelationalOp):
+  __slots__ = ('name','args')
+  def __init__(self, name, *args):
+    self.name = name
+    self.args = args
+


### PR DESCRIPTION
*\*  DO NOT MERGE: Early pull request for the purposes of discussion. **

Index seeking provides the ability for an adapter to return records from relations based on attribute look up rather than all the records at once (aka full table scan). To name a few uses of this:
- Replacing  a query containing a selection operation that references an indexed column  as in:

SelectionOp(LoadOp('blah'), Eq(Var('pk'), Const(1)) -> IndexSeek('blah', pk=1)

At evaluation time the dataset will then retrieve the need records by calling adapter.index_seek('blah', pk=1), which presumably will retrieve the matching record without performing a full table scan.
- Providing data from adapters that can only be queried when certain search terms are present. This will pave the way for capabilities based mediation  see infolab.stanford.edu/~yerneni/pubs/ccm.ps‎

My current thought is that LoadOp during evaluation will be replaced withe either TableScan or IndexSeek operations as determined by the Adapter. TableScan operation will be the equivalent of todays LoadOps, i.e. the adapter returns all records and lets the rest of the splicer machinery handle the relational operations. IndexSeek will return  a limited set of records. They'll have the ability to express which attributes must be bound in order to preform the IndexSeek.
